### PR TITLE
6.1-systray.diff: shift status text left

### DIFF
--- a/6.1/1625_cdec9782a1789bd5c3a84772fd59abb9da288597/dwm-6.1-systray.diff
+++ b/6.1/1625_cdec9782a1789bd5c3a84772fd59abb9da288597/dwm-6.1-systray.diff
@@ -8,7 +8,7 @@ Contributors:
 
 Index: dwm/config.def.h
 ===================================================================
---- dwm/config.def.h.orig
+--- dwm.orig/config.def.h
 +++ dwm/config.def.h
 @@ -10,6 +10,10 @@ static const char selbgcolor[]      = "#
  static const char selfgcolor[]      = "#eeeeee";
@@ -23,7 +23,7 @@ Index: dwm/config.def.h
  
 Index: dwm/dwm.c
 ===================================================================
---- dwm/dwm.c.orig
+--- dwm.orig/dwm.c
 +++ dwm/dwm.c
 @@ -56,12 +56,30 @@
  #define TAGMASK                 ((1 << LENGTH(tags)) - 1)
@@ -237,17 +237,30 @@ Index: dwm/dwm.c
  	for(c = m->clients; c; c = c->next) {
  		occ |= c->tags;
  		if(c->isurgent)
-@@ -726,6 +814,9 @@ drawbar(Monitor *m) {
+@@ -718,14 +806,21 @@ drawbar(Monitor *m) {
+ 	if(m == selmon) { /* status is only drawn on selected monitor */
+ 		w = TEXTW(stext);
+ 		x = m->ww - w;
++		if(showsystray && m == systraytomon(m)) {
++			x -= getsystraywidth();
++		}
+ 		if(x < xx) {
+ 			x = xx;
+ 			w = m->ww - xx;
+ 		}
+ 		drw_text(drw, x, 0, w, bh, stext, 0);
  	}
- 	else
+-	else
++	else {
  		x = m->ww;
-+	if(showsystray && m == systraytomon(m)) {
-+		x -= getsystraywidth();
-+	}
++		if(showsystray && m == systraytomon(m)) {
++			x -= getsystraywidth();
++		}
++    }
  	if((w = x - xx) > bh) {
  		x = xx;
  		if(m->sel) {
-@@ -747,6 +838,7 @@ drawbars(void) {
+@@ -747,6 +842,7 @@ drawbars(void) {
  
  	for(m = mons; m; m = m->next)
  		drawbar(m);
@@ -255,7 +268,7 @@ Index: dwm/dwm.c
  }
  
  void
-@@ -773,8 +865,11 @@ expose(XEvent *e) {
+@@ -773,8 +869,11 @@ expose(XEvent *e) {
  	Monitor *m;
  	XExposeEvent *ev = &e->xexpose;
  
@@ -268,7 +281,7 @@ Index: dwm/dwm.c
  }
  
  void
-@@ -857,10 +952,17 @@ getatomprop(Client *c, Atom prop) {
+@@ -857,10 +956,17 @@ getatomprop(Client *c, Atom prop) {
  	unsigned long dl;
  	unsigned char *p = NULL;
  	Atom da, atom = None;
@@ -287,7 +300,7 @@ Index: dwm/dwm.c
  		XFree(p);
  	}
  	return atom;
-@@ -892,6 +994,15 @@ getstate(Window w) {
+@@ -892,6 +998,15 @@ getstate(Window w) {
  	return result;
  }
  
@@ -303,7 +316,7 @@ Index: dwm/dwm.c
  Bool
  gettextprop(Window w, Atom atom, char *text, unsigned int size) {
  	char **list = NULL;
-@@ -992,7 +1103,7 @@ void
+@@ -992,7 +1107,7 @@ void
  killclient(const Arg *arg) {
  	if(!selmon->sel)
  		return;
@@ -312,7 +325,7 @@ Index: dwm/dwm.c
  		XGrabServer(dpy);
  		XSetErrorHandler(xerrordummy);
  		XSetCloseDownMode(dpy, DestroyAll);
-@@ -1078,6 +1189,12 @@ void
+@@ -1078,6 +1193,12 @@ void
  maprequest(XEvent *e) {
  	static XWindowAttributes wa;
  	XMapRequestEvent *ev = &e->xmaprequest;
@@ -325,7 +338,7 @@ Index: dwm/dwm.c
  
  	if(!XGetWindowAttributes(dpy, ev->window, &wa))
  		return;
-@@ -1194,6 +1311,16 @@ propertynotify(XEvent *e) {
+@@ -1194,6 +1315,16 @@ propertynotify(XEvent *e) {
  	Window trans;
  	XPropertyEvent *ev = &e->xproperty;
  
@@ -342,7 +355,7 @@ Index: dwm/dwm.c
  	if((ev->window == root) && (ev->atom == XA_WM_NAME))
  		updatestatus();
  	else if(ev->state == PropertyDelete)
-@@ -1243,12 +1370,33 @@ recttomon(int x, int y, int w, int h) {
+@@ -1243,12 +1374,33 @@ recttomon(int x, int y, int w, int h) {
  }
  
  void
@@ -376,7 +389,7 @@ Index: dwm/dwm.c
  resizeclient(Client *c, int x, int y, int w, int h) {
  	XWindowChanges wc;
  
-@@ -1315,6 +1463,18 @@ resizemouse(const Arg *arg) {
+@@ -1315,6 +1467,18 @@ resizemouse(const Arg *arg) {
  }
  
  void
@@ -395,7 +408,7 @@ Index: dwm/dwm.c
  restack(Monitor *m) {
  	Client *c;
  	XEvent ev;
-@@ -1398,25 +1558,35 @@ setclientstate(Client *c, long state) {
+@@ -1398,25 +1562,35 @@ setclientstate(Client *c, long state) {
  }
  
  Bool
@@ -442,7 +455,7 @@ Index: dwm/dwm.c
  	}
  	return exists;
  }
-@@ -1429,7 +1599,7 @@ setfocus(Client *c) {
+@@ -1429,7 +1603,7 @@ setfocus(Client *c) {
   		                XA_WINDOW, 32, PropModeReplace,
   		                (unsigned char *) &(c->win), 1);
  	}
@@ -451,7 +464,7 @@ Index: dwm/dwm.c
  }
  
  void
-@@ -1511,12 +1681,18 @@ setup(void) {
+@@ -1511,12 +1685,18 @@ setup(void) {
  	wmatom[WMTakeFocus] = XInternAtom(dpy, "WM_TAKE_FOCUS", False);
  	netatom[NetActiveWindow] = XInternAtom(dpy, "_NET_ACTIVE_WINDOW", False);
  	netatom[NetSupported] = XInternAtom(dpy, "_NET_SUPPORTED", False);
@@ -470,7 +483,7 @@ Index: dwm/dwm.c
  	/* init cursors */
  	cursor[CurNormal] = drw_cur_create(drw, XC_left_ptr);
  	cursor[CurResize] = drw_cur_create(drw, XC_sizing);
-@@ -1528,6 +1704,8 @@ setup(void) {
+@@ -1528,6 +1708,8 @@ setup(void) {
  	scheme[SchemeSel].border = drw_clr_create(drw, selbordercolor);
  	scheme[SchemeSel].bg = drw_clr_create(drw, selbgcolor);
  	scheme[SchemeSel].fg = drw_clr_create(drw, selfgcolor);
@@ -479,7 +492,7 @@ Index: dwm/dwm.c
  	/* init bars */
  	updatebars();
  	updatestatus();
-@@ -1583,6 +1761,22 @@ spawn(const Arg *arg) {
+@@ -1583,6 +1765,22 @@ spawn(const Arg *arg) {
  	}
  }
  
@@ -502,7 +515,7 @@ Index: dwm/dwm.c
  void
  tag(const Arg *arg) {
  	if(selmon->sel && arg->ui & TAGMASK) {
-@@ -1629,7 +1823,18 @@ void
+@@ -1629,7 +1827,18 @@ void
  togglebar(const Arg *arg) {
  	selmon->showbar = !selmon->showbar;
  	updatebarpos(selmon);
@@ -522,7 +535,7 @@ Index: dwm/dwm.c
  	arrange(selmon);
  }
  
-@@ -1719,11 +1924,18 @@ unmapnotify(XEvent *e) {
+@@ -1719,11 +1928,18 @@ unmapnotify(XEvent *e) {
  		else
  			unmanage(c, False);
  	}
@@ -541,7 +554,7 @@ Index: dwm/dwm.c
  	XSetWindowAttributes wa = {
  		.override_redirect = True,
  		.background_pixmap = ParentRelative,
-@@ -1732,10 +1944,15 @@ updatebars(void) {
+@@ -1732,10 +1948,15 @@ updatebars(void) {
  	for(m = mons; m; m = m->next) {
  		if (m->barwin)
  			continue;
@@ -558,7 +571,7 @@ Index: dwm/dwm.c
  		XMapRaised(dpy, m->barwin);
  	}
  }
-@@ -1929,6 +2146,117 @@ updatestatus(void) {
+@@ -1929,6 +2150,117 @@ updatestatus(void) {
  }
  
  void
@@ -676,7 +689,7 @@ Index: dwm/dwm.c
  updatewindowtype(Client *c) {
  	Atom state = getatomprop(c, netatom[NetWMState]);
  	Atom wtype = getatomprop(c, netatom[NetWMWindowType]);
-@@ -1997,6 +2325,16 @@ wintomon(Window w) {
+@@ -1997,6 +2329,16 @@ wintomon(Window w) {
  	return selmon;
  }
  


### PR DESCRIPTION
commit cfbaa7d shifted the status text to the right causing it to be
obscured by the systray.

Signed-off-by: Andrew Gregory andrew.gregory.8@gmail.com
